### PR TITLE
Patch JTE PR #199

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,6 @@ dependencies {
     implementation 'org.jenkins-ci.plugins:branch-api:2.0.20'
     implementation 'org.jenkins-ci.plugins:scm-api:2.2.7'
     implementation 'org.jenkins-ci.plugins:junit:1.24'
-    implementation 'org.jenkins-ci.plugins:github-branch-source:2.5.1'
     implementation 'org.jenkins-ci.plugins:script-security:1.76'
     implementation 'org.jgrapht:jgrapht-core:1.4.0'
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'groovy'
-  id 'org.jenkins-ci.jpi' version '0.42.0'
+  id 'org.jenkins-ci.jpi' version '0.43.0'
   id 'jacoco'
   id "com.diffplug.gradle.spotless" version "3.29.0"
   id 'codenarc'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ version = '2.2'
 description = 'Allows users to create tool-agnostic, templated pipelines to be shared by multiple teams'
 
 jenkinsPlugin {
-    coreVersion = '2.176.4'
+    coreVersion = '2.263.1'
     shortName = 'templating-engine'
     displayName = 'Templating Engine'
     url = 'https://github.com/jenkinsci/templating-engine-plugin'
@@ -48,6 +48,7 @@ dependencies {
     implementation 'org.jenkins-ci.plugins:scm-api:2.2.7'
     implementation 'org.jenkins-ci.plugins:junit:1.24'
     implementation 'org.jenkins-ci.plugins:script-security:1.76'
+    implementation 'org.jenkinsci.plugins:pipeline-model-definition:1.8.4' // version declarative started supporting JTE
     implementation 'org.jgrapht:jgrapht-core:1.4.0'
 
     // unit test dependencies
@@ -65,11 +66,12 @@ dependencies {
     // test plugins
     testImplementation(group: "org.jenkins-ci.plugins.workflow", name: "workflow-support", classifier: "tests")
     testImplementation(group: "org.jenkins-ci.plugins", name: "scm-api", version: "2.3.0", classifier: "tests")
-    testImplementation(group: 'org.jenkins-ci.plugins', name: 'git', version:'3.9.3') {
+    testImplementation(group: 'org.jenkins-ci.plugins', name: 'git', version:'4.7.1') {
         exclude(module: 'httpclient')
         exclude(module: 'annotation-indexer')
     }
-    testImplementation 'org.jenkins-ci.plugins:token-macro:1.12.1'
+    testImplementation 'org.jenkins-ci.plugins:token-macro:2.13'
+    testImplementation 'org.jenkins-ci.plugins:matrix-project:1.18'
     testImplementation 'org.jenkins-ci.plugins.workflow:workflow-aggregator:2.6'
     testImplementation 'org.jenkins-ci.plugins.workflow:workflow-step-api:2.19'
 }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitive.groovy
@@ -41,10 +41,12 @@ abstract class TemplatePrimitive extends GlobalVariable implements Serializable{
     String name
     TemplatePrimitiveNamespace parent
 
-    @Override
+    @SuppressWarnings("UnusedMethodParameter")
     @NonCPS
-    Object getValue(@Nonnull CpsScript script) throws Exception {
-        isOverloaded()
+    Object getValue(@Nonnull CpsScript script, Boolean skipOverloaded = false) throws Exception {
+        if(! skipOverloaded){
+            isOverloaded()
+        }
         return this
     }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveNamespace.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/TemplatePrimitiveNamespace.groovy
@@ -37,7 +37,7 @@ class TemplatePrimitiveNamespace implements Serializable {
     Object getProperty(String property){
         TemplatePrimitive primitive = primitives.find{ p -> p.getName() == property }
         if(primitive){
-            return primitive.getValue(null)
+            return primitive.getValue(null, true)
         }
         throw new JTEException("Primitive ${property} not found in ${name}")
     }
@@ -45,7 +45,7 @@ class TemplatePrimitiveNamespace implements Serializable {
     Object methodMissing(String methodName, Object args){
         TemplatePrimitive primitive = primitives.find{ p -> p.getName() == methodName }
         if(primitive){
-            return primitive.getValue(null).call(args)
+            return primitive.getValue(null, true).call(args)
         }
         throw new JTEException("Primitive ${methodName} not found in ${name}")
     }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/DefaultStepInjector.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/DefaultStepInjector.groovy
@@ -52,7 +52,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowExecutionOwner
             } else { // otherwise go ahead and create the default step implementation
                 logger.print "Creating step ${stepName} from the default step implementation."
                 StepWrapper step = stepFactory.createDefaultStep(stepName, stepConfig)
-                step.addParent(steps)
+                step.setParent(steps)
                 steps.add(step)
             }
         }

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Keyword.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Keyword.groovy
@@ -29,8 +29,11 @@ class Keyword extends TemplatePrimitive{
 
     @Override String getName(){ return name }
     @Override String toString(){ return "Keyword '${name}'" }
-    @Override Object getValue(CpsScript script){
-        isOverloaded()
+    @SuppressWarnings("UnusedMethodParameter")
+    Object getValue(CpsScript script, Boolean skipOverloaded = false){
+        if(! skipOverloaded){
+            isOverloaded()
+        }
         return value
     }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/Stage.groovy
@@ -44,8 +44,11 @@ class Stage extends TemplatePrimitive{
         return "Stage '${name}'"
     }
 
-    @Override Object getValue(CpsScript script){
-        isOverloaded()
+    @SuppressWarnings("UnusedMethodParameter")
+    Object getValue(CpsScript script, Boolean skipOverloaded = false){
+        if(! skipOverloaded){
+            isOverloaded()
+        }
         return getCPSClass().newInstance(name: name, steps: steps)
     }
 

--- a/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/init/primitives/injectors/StepWrapper.groovy
@@ -86,9 +86,12 @@ class StepWrapper extends TemplatePrimitive implements Serializable, Cloneable{
     @Override String getName(){ return name }
     String getLibrary(){ return library }
 
-    @Override
-    Object getValue(CpsScript script){
-        isOverloaded()
+    @SuppressWarnings("UnusedMethodParameter")
+    Object getValue(CpsScript script, Boolean skipOverloaded = false){
+        // if permissive_initialization is true, overloaded is okay
+        if(! skipOverloaded){
+            isOverloaded()
+        }
         Class stepwrapperCPS = getPrimitiveClass()
         def s = stepwrapperCPS.newInstance(
             name: this.name,

--- a/src/main/groovy/org/boozallen/plugins/jte/job/TemplateFlowDefinition.groovy
+++ b/src/main/groovy/org/boozallen/plugins/jte/job/TemplateFlowDefinition.groovy
@@ -51,15 +51,13 @@ abstract class TemplateFlowDefinition extends FlowDefinition {
 
     @Override
     FlowExecution create(FlowExecutionOwner owner, TaskListener listener, List<? extends Action> actions) throws Exception {
-        FlowDurabilityHint hint = determineFlowDurabilityHint(owner)
-        String template = initializeJTE(owner)
-
-        // For restart from stage.  Needs initializeJTE to be run.
         for (Action a : actions) {
             if (a instanceof CpsFlowFactoryAction2) {
                 return ((CpsFlowFactoryAction2) a).create(this, owner, actions)
             }
         }
+        FlowDurabilityHint hint = determineFlowDurabilityHint(owner)
+        String template = initializeJTE(owner)
 
         return new CpsFlowExecution(template, true, owner, hint)
     }

--- a/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StageCPS.groovy
+++ b/src/main/resources/org/boozallen/plugins/jte/init/primitives/injectors/StageCPS.groovy
@@ -47,7 +47,7 @@ class StageCPS extends Stage{
             }
             StepWrapper clone = s.first().clone()
             clone.setStageContext(stageContext)
-            clone.getValue().call()
+            clone.getValue(null).call()
         }
     }
 

--- a/src/test/groovy/org/boozallen/plugins/jte/init/RestartFromStageSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/RestartFromStageSpec.groovy
@@ -176,17 +176,4 @@ class RestartFromStageSpec extends Specification {
         jenkins.assertLogContains('contents:Hi I was stashed', b2)
     }
 
-    // inspired (lifted) from https://github.com/jenkinsci/pipeline-model-definition-plugin/blob/master/pipeline-model-definition/src/test/java/org/jenkinsci/plugins/pipeline/modeldefinition/actions/RestartDeclarativePipelineActionTest.java#L783-L793
-    private HtmlPage restartFromStageInUI(WorkflowRun original, String stageName) throws Exception {
-        RestartDeclarativePipelineAction action = original.getAction(RestartDeclarativePipelineAction)
-        assert action != null
-        assert action.isRestartEnabled()
-
-        HtmlPage page = jenkins.createWebClient().getPage(original, action.getUrlName())
-        HtmlForm form = page.getFormByName("restart")
-        HtmlSelect select = form.getSelectByName("stageName")
-        select.getOptionByValue(stageName).setSelected(true)
-        return jenkins.submit(form)
-    }
-
 }

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
@@ -141,7 +141,7 @@ class TemplateBindingSpec extends Specification {
 
     def "Invoking overloaded step via namespace works when permissive_initialization is true"(){
         given:
-//        CpsVmExecutorService.FAIL_ON_MISMATCH = false
+        CpsVmExecutorService.FAIL_ON_MISMATCH = false // needed for unit test.
         TestLibraryProvider libProvider = new TestLibraryProvider()
         libProvider.addStep('maven', 'build', 'void call(){ println "build from maven" }')
         libProvider.addStep('gradle', 'build', 'void call(){ println "build from gradle" }')

--- a/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
+++ b/src/test/groovy/org/boozallen/plugins/jte/init/primitives/TemplateBindingSpec.groovy
@@ -22,6 +22,7 @@ import org.boozallen.plugins.jte.init.primitives.injectors.Keyword
 import org.boozallen.plugins.jte.init.primitives.injectors.Stage
 import org.boozallen.plugins.jte.init.primitives.injectors.StepWrapper
 import org.boozallen.plugins.jte.util.TestUtil
+import org.jenkinsci.plugins.workflow.cps.CpsVmExecutorService
 import org.jenkinsci.plugins.workflow.job.WorkflowJob
 import org.junit.ClassRule
 import org.jvnet.hudson.test.JenkinsRule
@@ -140,6 +141,7 @@ class TemplateBindingSpec extends Specification {
 
     def "Invoking overloaded step via namespace works when permissive_initialization is true"(){
         given:
+//        CpsVmExecutorService.FAIL_ON_MISMATCH = false
         TestLibraryProvider libProvider = new TestLibraryProvider()
         libProvider.addStep('maven', 'build', 'void call(){ println "build from maven" }')
         libProvider.addStep('gradle', 'build', 'void call(){ println "build from gradle" }')


### PR DESCRIPTION
Hey @chrishiner - submitting some fixes to this PR for your review. 

Wanted to make sure our release notes automation captured you as the submitter for the PR which is why i'm merging back here first. 

You were on the right track with the loop for the `CpsFlowFactoryAction2` in `TemplateFlowDefinition` 

needed to just add an extension for a `FlowCopier` in `TemplatePrimitiveCollector` so that when the job restarts it uses the previous run's JTE primitives (steps and what not). 

Needed to upgrade our test dependencies to include the version of declarative (pipeline-model-definition) that supports JTE, which trigged some cascading dependency upgrades that were needed. 

Overall, tests are passing and i tested manually and it seems to be working as well. 

Please review and merge when you're ready and we can get this merged into JTE. 

I also updated the branch w/ the latest changes from `main` which is why you'll see a few unrelated changes. 